### PR TITLE
Features/OpenApi Importer

### DIFF
--- a/build/npm/macos/package.json
+++ b/build/npm/macos/package.json
@@ -4,7 +4,8 @@
   "description": "Qala CLI is a command-line interface tool for macOS, designed to simplify and automate various tasks for developers that are using the Qala Q-Flow.",
   "main": "index.js",
   "scripts": {
-    "test": "qala --help"
+    "test": "qala --help",
+    "postinstall": "chmod +x ./bin/qala"
   },
   "repository": {
     "type": "git",

--- a/pipelines/build-deploy-qala-cli.yml
+++ b/pipelines/build-deploy-qala-cli.yml
@@ -7,6 +7,11 @@ trigger:
     include:
       - releases/*
 
+pr:
+  branches:
+    exclude:
+      - '*'
+
 variables:
   pathToTheProjectFile: '$(Build.SourcesDirectory)/src/Qala.Cli/Qala.Cli.csproj' 
   pathToTheProjectTestFile: '$(Build.SourcesDirectory)/tests/Qala.Cli.Integration.Tests/Qala.Cli.Integration.Tests.csproj' 

--- a/pipelines/build-deploy-qala-cli.yml
+++ b/pipelines/build-deploy-qala-cli.yml
@@ -345,7 +345,7 @@ stages:
           displayName: 'Move the README.md file into the npm folder'
           inputs:
             SourceFolder: '$(Build.SourcesDirectory)'
-            Contents: 'README.md'
+            Contents: 'README.MD'
             TargetFolder: '$(Build.SourcesDirectory)/build/npm/linux'
 
         # Update the version in the package.json file

--- a/src/Qala.Cli.Data/Gateway/EventTypeGateway.cs
+++ b/src/Qala.Cli.Data/Gateway/EventTypeGateway.cs
@@ -46,7 +46,7 @@ public class EventTypeGateway(HttpClient client) : IEventTypeGateway
 
             var jsonResponse = await response.Content.ReadAsStringAsync();
             using var jsonDocument = JsonDocument.Parse(jsonResponse);
-            var totalImported = jsonDocument.RootElement.GetProperty("TotalImported").GetInt32();
+            var totalImported = jsonDocument.RootElement.GetProperty("totalImported").GetInt32();
 
             return totalImported;
         }

--- a/src/Qala.Cli.Data/Gateway/Interfaces/IEventTypeGateway.cs
+++ b/src/Qala.Cli.Data/Gateway/Interfaces/IEventTypeGateway.cs
@@ -6,4 +6,5 @@ public interface IEventTypeGateway
 {
     Task<IEnumerable<EventType>> ListEventTypesAsync();
     Task<EventType?> GetEventTypeAsync(Guid id);
+    Task<int> ImportOpenApiSpecAsync(string specFilePath);
 }

--- a/src/Qala.Cli/Commands/EventTypes/CreateEventTypesArgument.cs
+++ b/src/Qala.Cli/Commands/EventTypes/CreateEventTypesArgument.cs
@@ -1,0 +1,11 @@
+using System.ComponentModel;
+using Spectre.Console.Cli;
+
+namespace Qala.Cli.Commands.EventTypes;
+
+public class CreateEventTypeArgument : CommandSettings
+{
+    [CommandOption("-i|--import <IMPORT_FILE_PATH>")]
+    [Description("The path to the file containing the event type definition.")]
+    public string ImportFilePath { get; set; } = string.Empty;
+}

--- a/src/Qala.Cli/Commands/EventTypes/CreateEventTypesCommand.cs
+++ b/src/Qala.Cli/Commands/EventTypes/CreateEventTypesCommand.cs
@@ -1,0 +1,72 @@
+using MediatR;
+using Qala.Cli.Utils;
+using Spectre.Console;
+using Spectre.Console.Cli;
+
+namespace Qala.Cli.Commands.EventTypes;
+
+public class CreateEventTypesCommand(IMediator mediator, IAnsiConsole console) : AsyncCommand<CreateEventTypeArgument>
+{
+    public override async Task<int> ExecuteAsync(CommandContext context, CreateEventTypeArgument argument)
+    {
+        return await console.Status()
+            .AutoRefresh(true)
+            .Spinner(Spinner.Known.Star2)
+            .SpinnerStyle(Style.Parse("yellow bold"))
+            .StartAsync("Processing request...", async ctx =>
+            {
+                return await mediator.Send(new CreateEventTypesRequest(argument.ImportFilePath))
+                    .ToAsync()
+                    .Match(
+                        success =>
+                        {
+                            BaseCommands.DisplaySuccessMessage("Event Types", BaseCommands.CommandAction.Create, console);
+                            var grid = new Grid()
+                                .AddColumns(4)
+                                .AddRow(
+                                    new Text("Id", new Style(decoration: Decoration.Bold)),
+                                    new Text("Type", new Style(decoration: Decoration.Bold)),
+                                    new Text("Description", new Style(decoration: Decoration.Bold)),
+                                    new Text("Content Type", new Style(decoration: Decoration.Bold))
+                                );
+
+                            foreach (var eventType in success.EventTypes)
+                            {
+                                grid.AddRow(
+                                    new Text(eventType.Id.ToString()),
+                                    new Text(eventType.Type),
+                                    new Text(eventType.Description),
+                                    new Text(eventType.ContentType)
+                                );
+                            }
+                            console.Write(grid);
+
+                            return 0;
+                        },
+                        error =>
+                        {
+                            BaseCommands.DisplayErrorMessage("Event Types", BaseCommands.CommandAction.Create, error.Message, console);
+                            return -1;
+                        }
+                    );
+            });
+    }
+
+    public override ValidationResult Validate(CommandContext context, CreateEventTypeArgument argument)
+    {
+        if (string.IsNullOrWhiteSpace(argument.ImportFilePath))
+        {
+            return ValidationResult.Error("Import file path is required.");
+        }
+
+        var allowedExtensions = new[] { ".yaml", ".yml", ".json" };
+        var fileExtension = Path.GetExtension(argument.ImportFilePath);
+
+        if (!allowedExtensions.Contains(fileExtension, StringComparer.OrdinalIgnoreCase))
+        {
+            return ValidationResult.Error("The import file must have a .yaml, .yml, or .json extension.");
+        }
+
+        return ValidationResult.Success();
+    }
+}

--- a/src/Qala.Cli/Commands/EventTypes/CreateEventTypesHandler.cs
+++ b/src/Qala.Cli/Commands/EventTypes/CreateEventTypesHandler.cs
@@ -1,0 +1,23 @@
+using LanguageExt;
+using MediatR;
+using Qala.Cli.Services.Interfaces;
+
+namespace Qala.Cli.Commands.EventTypes;
+
+public record CreateEventTypesSuccessResponse(List<Data.Models.EventType> EventTypes);
+public record CreateEventTypesErrorResponse(string Message);
+public record CreateEventTypesRequest(string ImportFilePath) : IRequest<Either<CreateEventTypesErrorResponse, CreateEventTypesSuccessResponse>>;
+
+public class CreateEventTypesHandler(IEventTypeService eventTypeService)
+    : IRequestHandler<CreateEventTypesRequest, Either<CreateEventTypesErrorResponse, CreateEventTypesSuccessResponse>>
+{
+    public async Task<Either<CreateEventTypesErrorResponse, CreateEventTypesSuccessResponse>> Handle(CreateEventTypesRequest request, CancellationToken cancellationToken)
+     => await eventTypeService.CreateEventTypesAsync(request.ImportFilePath)
+        .ToAsync()
+        .Case switch
+     {
+         CreateEventTypesSuccessResponse success => success,
+         CreateEventTypesErrorResponse error => error,
+         _ => throw new NotImplementedException()
+     };
+}

--- a/src/Qala.Cli/Commands/SubscriberGroups/UpdateSubscriberGroupArgument.cs
+++ b/src/Qala.Cli/Commands/SubscriberGroups/UpdateSubscriberGroupArgument.cs
@@ -25,5 +25,6 @@ public class UpdateSubscriberGroupArgument : CommandSettings
 
     [CommandOption("-a|--audience <AUDIENCE>")]
     [Description("The audience to scope the subscriber group.")]
+    [DefaultValue(null)]
     public string? Audience { get; set; } = null;
 }

--- a/src/Qala.Cli/Program.cs
+++ b/src/Qala.Cli/Program.cs
@@ -66,6 +66,9 @@ app.Configure(config =>
             .WithDescription("this command retrieves the event type with the specified ID.")
             .WithExample("events inspect <EVENT_TYPE_NAME>")
             .WithAlias("i");
+        et.AddCommand<CreateEventTypesCommand>("create")
+            .WithDescription("this command creates a new event type for the Qala CLI.")
+            .WithExample("events create -i <IMPORT_FILE_PATH>");
     })
     .WithAlias("ev");
 

--- a/src/Qala.Cli/Services/EventTypeService.cs
+++ b/src/Qala.Cli/Services/EventTypeService.cs
@@ -7,6 +7,24 @@ namespace Qala.Cli.Services;
 
 public class EventTypeService(IEventTypeGateway eventTypeGateway) : IEventTypeService
 {
+    public async Task<Either<CreateEventTypesErrorResponse, CreateEventTypesSuccessResponse>> CreateEventTypesAsync(string importFilePath)
+    {
+        if (string.IsNullOrWhiteSpace(importFilePath))
+        {
+            return await Task.FromResult<Either<CreateEventTypesErrorResponse, CreateEventTypesSuccessResponse>>(new CreateEventTypesErrorResponse("Import file path is required"));
+        }
+
+        var numberOfEventTypesImported = await eventTypeGateway.ImportOpenApiSpecAsync(importFilePath);
+
+        if (numberOfEventTypesImported == 0)
+        {
+            return await Task.FromResult<Either<CreateEventTypesErrorResponse, CreateEventTypesSuccessResponse>>(new CreateEventTypesErrorResponse("No event types imported"));
+        }
+
+        var eventTypes = await eventTypeGateway.ListEventTypesAsync();
+        return await Task.FromResult<Either<CreateEventTypesErrorResponse, CreateEventTypesSuccessResponse>>(new CreateEventTypesSuccessResponse([.. eventTypes]));
+    }
+
     public async Task<Either<GetEventTypeErrorResponse, GetEventTypeSuccessResponse>> GetEventTypeAsync(string name)
     {
         if (string.IsNullOrWhiteSpace(name))

--- a/src/Qala.Cli/Services/Interfaces/IEventTypeService.cs
+++ b/src/Qala.Cli/Services/Interfaces/IEventTypeService.cs
@@ -7,4 +7,5 @@ public interface IEventTypeService
 {
     Task<Either<ListEventTypesErrorResponse, ListEventTypesSuccessResponse>> ListEventTypesAsync();
     Task<Either<GetEventTypeErrorResponse, GetEventTypeSuccessResponse>> GetEventTypeAsync(string name);
+    Task<Either<CreateEventTypesErrorResponse, CreateEventTypesSuccessResponse>> CreateEventTypesAsync(string importFilePath);
 }

--- a/src/Qala.Cli/generatedDocs/qala-cli-docs/qala-cli-events.mdx
+++ b/src/Qala.Cli/generatedDocs/qala-cli-docs/qala-cli-events.mdx
@@ -34,6 +34,8 @@ import HeroBanner from '../../../src/components/HeroBanner/HeroBanner';
 environment.</td></tr>
 <tr><td><a href="#inspect" title="Learn about inspect">inspect</a></td><td>this command retrieves the event type with the specified 
 ID.</td></tr>
+<tr><td><a href="#create" title="Learn about create">create</a></td><td>this command creates a new event type for the Qala 
+CLI.</td></tr>
 </table>
 ### `list`
 this command lists all the event types available in your 
@@ -56,6 +58,22 @@ ID.
 **Examples:**
 ```sh
 events inspect <EVENT_TYPE_NAME>
+```
+
+
+### `create`
+this command creates a new event type for the Qala 
+CLI.
+
+**Options:**
+<table>
+<tr><th>Option</th><th>Description</th></tr>
+<tr><td>`i` / `import`</td><td>The path to the file containing the event type 
+definition.</td></tr>
+</table>
+**Examples:**
+```sh
+events create -i <IMPORT_FILE_PATH>
 ```
 
 

--- a/src/Qala.Cli/generatedDocs/qala-cli-xmldoc.xml
+++ b/src/Qala.Cli/generatedDocs/qala-cli-xmldoc.xml
@@ -134,6 +134,23 @@ Kind="scalar" ClrType="System.String">
         <Example commandLine="events inspect &lt;EVENT_TYPE_NAME&gt;" />
       </Examples>
     </Command>
+    <!--CREATE-->
+    <Command Name="create" IsBranch="false" 
+ClrType="Qala.Cli.Commands.EventTypes.CreateEventTypesCommand" 
+Settings="Qala.Cli.Commands.EventTypes.CreateEventTypeArgument">
+      <Description>this command creates a new event type for the Qala 
+CLI.</Description>
+      <Parameters>
+        <Option Short="i" Long="import" Value="IMPORT_FILE_PATH" 
+Required="false" Kind="scalar" ClrType="System.String">
+          <Description>The path to the file containing the event type 
+definition.</Description>
+        </Option>
+      </Parameters>
+      <Examples>
+        <Example commandLine="events create -i &lt;IMPORT_FILE_PATH&gt;" />
+      </Examples>
+    </Command>
   </Command>
   <!--TOPICS-->
   <Command Name="topics" IsBranch="true" 


### PR DESCRIPTION
## ✅ OpenAPI Importer

This feature allows users to import an OpenAPI specification (version **3.0** or **3.1**) to automatically generate all corresponding **event types** and **categories** within their Q-Flow environment.

### 🔹 Supported File Formats
- `.yaml`
- `.yml`
- `.json`

> ℹ️ Only OpenAPI specs using version **3.0** or **3.1** are supported.